### PR TITLE
Fix cache-control header issue in Next.js

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -21,6 +21,10 @@ module.exports = bundleAnalyzer({
             value:
               'frame-ancestors https://*.builder.io https://builder.io http://localhost:1234',
           },
+          {
+            key: 'Cache-Control',
+            value: 'no-store',
+          },
         ],
       },
     ]


### PR DESCRIPTION
Related to #52

Add cache-control header configuration to prevent CDN caching empty replies.

* Modify `next.config.js` to include a `Cache-Control` header with a value of `no-store`.

